### PR TITLE
Enable full permissions checking to handle ACLs

### DIFF
--- a/MNI/FileUtilities.pm
+++ b/MNI/FileUtilities.pm
@@ -859,6 +859,7 @@ sub search_directories
    foreach $dir (@dirs)
    {
       $_ = $dir . $file;
+      use filetest 'access';
       $found = eval $test;
       croak ("bad test: $test ($@)") if $@;
       return $dir if $found;


### PR DESCRIPTION
Perl by default just checks the permission bits to check for access to files. This fails on systems where access is granted via ACLs (Niagara supercomputer for example). Enable full checking via access() system call to work properly.

See https://perldoc.perl.org/functions/-X.html